### PR TITLE
Add BringStudy agenda CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ studypilot
 python -m studypilot
 ```
 
+### BringStudy (agenda CLI)
+```bash
+bringstudy list            # lister les entrées
+bringstudy add "Titre" 2024-06-01 -c exam -d "Description"
+```
+
 ## Données locales par utilisateur
 - Windows: %APPDATA%/StudyPilotLocal
 - macOS: ~/Library/Application Support/StudyPilotLocal

--- a/bringstudy/__init__.py
+++ b/bringstudy/__init__.py
@@ -1,0 +1,4 @@
+"""BringStudy - simple agenda for teens 14-18."""
+from .agenda import Agenda, Entry
+
+__all__ = ["Agenda", "Entry"]

--- a/bringstudy/__main__.py
+++ b/bringstudy/__main__.py
@@ -1,0 +1,40 @@
+import argparse
+from .agenda import Agenda, Entry
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="bringstudy",
+        description="BringStudy - agenda for students aged 14-18",
+    )
+    sub = parser.add_subparsers(dest="cmd")
+
+    add_p = sub.add_parser("add", help="Add a new agenda entry")
+    add_p.add_argument("title", help="Short title for the entry")
+    add_p.add_argument("date", help="Date of the entry (YYYY-MM-DD)")
+    add_p.add_argument(
+        "-c", "--category", default="note", help="Category such as exam or schedule"
+    )
+    add_p.add_argument("-d", "--description", default="", help="Optional description")
+
+    sub.add_parser("list", help="List all entries")
+
+    args = parser.parse_args()
+    agenda = Agenda()
+
+    if args.cmd == "add":
+        entry = Entry(
+            title=args.title,
+            date=args.date,
+            category=args.category,
+            description=args.description,
+        )
+        agenda.add_entry(entry)
+        print("Entry added")
+    else:
+        for entry in agenda.list_entries():
+            print(f"{entry.date} [{entry.category}] {entry.title} - {entry.description}")
+
+
+if __name__ == "__main__":
+    main()

--- a/bringstudy/agenda.py
+++ b/bringstudy/agenda.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from pathlib import Path
+import json
+from typing import List
+
+
+@dataclass
+class Entry:
+    """Agenda entry representing an exam, schedule item, or note."""
+
+    title: str
+    date: str
+    category: str = "note"
+    description: str = ""
+
+
+class Agenda:
+    """Persist agenda entries to a local JSON file."""
+
+    def __init__(self, storage_path: Path | None = None) -> None:
+        if storage_path is None:
+            storage_path = Path.home() / ".local" / "share" / "BringStudy"
+        self.storage_dir = storage_path
+        self.storage_dir.mkdir(parents=True, exist_ok=True)
+        self.file = self.storage_dir / "agenda.json"
+        if not self.file.exists():
+            self._save([])
+
+    def _load(self) -> List[Entry]:
+        with self.file.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        return [Entry(**item) for item in data]
+
+    def _save(self, entries: List[Entry]) -> None:
+        with self.file.open("w", encoding="utf-8") as fh:
+            json.dump([asdict(e) for e in entries], fh, indent=2)
+
+    def add_entry(self, entry: Entry) -> None:
+        entries = self._load()
+        entries.append(entry)
+        self._save(entries)
+
+    def list_entries(self) -> List[Entry]:
+        return self._load()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,3 +13,4 @@ dependencies = ["PyQt5>=5.15"]
 
 [project.scripts]
 studypilot = "studypilot.__main__:main"
+bringstudy = "bringstudy.__main__:main"


### PR DESCRIPTION
## Summary
- add BringStudy package with simple agenda for teens
- persist notes in JSON storage
- expose bringstudy command-line interface

## Testing
- `python -m bringstudy list`
- `python -m bringstudy add "Math Exam" 2024-06-01 -c exam -d "Chapters 1-5"`
- `python -m bringstudy list`


------
https://chatgpt.com/codex/tasks/task_e_68aca82281d083209ef0b3bc6b2a788a